### PR TITLE
Update vote calculation to support payment_v2

### DIFF
--- a/jobs/calculate-results.js
+++ b/jobs/calculate-results.js
@@ -54,7 +54,7 @@ const calculateResultsForVote = async (id) => {
       allRoles.push(...payments);
     }));
 
-    await PromisePool.for(allRoles).withConcurrency(3).process(async ({hash, height}) => {
+    await PromisePool.for(allRoles).withConcurrency(5).process(async ({hash, height}) => {
       if (height > deadline) return;
 
       const txn = await client.transactions.get(hash);
@@ -98,7 +98,7 @@ const calculateResultsForVote = async (id) => {
         let summedVotedHnt = 0.0;
         let votingWallets = 0;
 
-        await PromisePool.for(ungroupedTalliesToCount).withConcurrency(3).process(async ({ height, payer: voter, payee }) => {
+        await PromisePool.for(ungroupedTalliesToCount).withConcurrency(5).process(async ({ height, payer: voter, payee }) => {
           if (height > deadline) return;
 
           // tally the votes for this outcome, skip everything else

--- a/jobs/calculate-results.js
+++ b/jobs/calculate-results.js
@@ -15,7 +15,7 @@ const fetchVoteDetails = async (id) => {
 const calculateResultsForVote = async (id) => {
   try {
     console.log("fetching vote details for:", id);
-    const { outcomes, deadline } = await fetchVoteDetails(id);
+    const { outcomes, deadline, filters } = await fetchVoteDetails(id);
 
     // initialize empty results object
     const results = {};
@@ -58,6 +58,10 @@ const calculateResultsForVote = async (id) => {
       if (height > deadline) return;
 
       const txn = await client.transactions.get(hash);
+
+      // apply filters
+      if (filters && filters.length > 0 && filters.includes(txn.payer)) return;
+
       switch (txn.type) {
         case "payment_v2":
           txn.payments.forEach(({ payee }) => {

--- a/jobs/calculate-results.js
+++ b/jobs/calculate-results.js
@@ -53,7 +53,7 @@ const calculateResultsForVote = async (id) => {
 
     const allBurnPayTxns = [];
     await Promise.all(
-      allBurnRoles.map(async ({ hash, height}) => {
+      await PromisePool.for(allBurnRoles).withConcurrency(3).process(async ({hash, height}) => {
         if (height > deadline) return;
 
         const txn = await client.transactions.get(hash);
@@ -81,7 +81,7 @@ const calculateResultsForVote = async (id) => {
         let summedVotedHnt = 0.0;
         let votingWallets = 0;
 
-        await PromisePool.for(ungroupedAllVotesToCount).process(async (txn) => {
+        await PromisePool.for(ungroupedAllVotesToCount).withConcurrency(3).process(async (txn) => {
           if (txn.height > deadline) return;
 
           // tally the votes for this outcome, skip everything else

--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,8 @@ const templateExample = {
       color: "#EEEEEE",
     },
   ],
+  // any addresses you want to filter for voting. for example, an exchange wallet address
+  filters: [],
 };
 
 module.exports = {
@@ -77,6 +79,7 @@ module.exports = {
       //       address: "13yWhaorHn8Es6jujCw9HCFAjDyecCv5HMwzoa4gp26awSw7z3b",
       //     },
       //   ],
+      //   filters: [],
       // },
       {
         id: "14MnuexopPfDg3bmq8JdCm7LMDkUBoqhqanD9QzLrUURLZxFHBx",
@@ -549,6 +552,13 @@ module.exports = {
             value: "Against HIP 70",
             address: "13EUfEDbJVXtzrf3fn1mX1fj8NtYLiik56WdaZB5vEEjr66pRMm",
           },
+        ],
+        filters: [
+          // these are known exchange wallets
+          "14YeKFGXE23yAdACj6hu5NWEcYzzKxptYbm5jHgzw9A1P1UQfMv",
+          "13HPSdf8Ng8E2uKpLm8Ba3sQ6wdNimTcaKXYmMkHyTUUeUELPwJ",
+          "13PBfQf1kaZPD3zN8LyoY5QtEDSZKJYZS5N7S5hZYaEz2Kh8znT",
+          "13d4ieU8x4n3v7XtkiLio1NmT9WzKJS4BFC7jDJNbGjB5xciQC8",
         ],
       }
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -554,11 +554,11 @@ module.exports = {
           },
         ],
         filters: [
-          // these are known exchange wallets
-          "14YeKFGXE23yAdACj6hu5NWEcYzzKxptYbm5jHgzw9A1P1UQfMv",
-          "13HPSdf8Ng8E2uKpLm8Ba3sQ6wdNimTcaKXYmMkHyTUUeUELPwJ",
-          "13PBfQf1kaZPD3zN8LyoY5QtEDSZKJYZS5N7S5hZYaEz2Kh8znT",
-          "13d4ieU8x4n3v7XtkiLio1NmT9WzKJS4BFC7jDJNbGjB5xciQC8",
+          // these are known exchange wallets, more can be added before the vote closes.
+          "14YeKFGXE23yAdACj6hu5NWEcYzzKxptYbm5jHgzw9A1P1UQfMv", // binance.com
+          "13HPSdf8Ng8E2uKpLm8Ba3sQ6wdNimTcaKXYmMkHyTUUeUELPwJ", // binance.us
+          "13PBfQf1kaZPD3zN8LyoY5QtEDSZKJYZS5N7S5hZYaEz2Kh8znT", // crypto.com
+          "13d4ieU8x4n3v7XtkiLio1NmT9WzKJS4BFC7jDJNbGjB5xciQC8", // kucoin
         ],
       }
     ],


### PR DESCRIPTION
**Requirements:** Some voters are having trouble voting with their wallets held in multi-signature wallets. We'd like to enable these voters to vote by issuing micropayments instead of token burns.

Notes:
* This is a common error by other voters but usually they realize that they need to burn instead of pay.
* We do want to protect against arbitrary voting from exchange wallets. Some have been filtered. This list may need to be updated.
* The logic stays the same, we just will recognize payments as well as token burns.
* The token balance of the voter account at the time of the deadline will be still used for the final vote tally.
* The live vote tally is the current balance of the voter account.
* A subsequent burn (or payment) to one of the outcome addresses can be still used to change an older vote.
