### PR TITLE
Unblock data loading from Reown/WalletConnect init

### DIFF
--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -12,18 +12,13 @@ import { toast } from "sonner";
 import { CoinbaseWalletAdapter } from "@solana/wallet-adapter-wallets";
 import { useWrappedReownAdapter } from "@jup-ag/jup-mobile-adapter";
 
-// Default styles that can be overridden by your app
 require("@solana/wallet-adapter-react-ui/styles.css");
 
-export const WalletProvider: FC<React.PropsWithChildren> = ({ children }) => {
-  // You can also provide a custom RPC endpoint.
-  const endpoint = useMemo(
-    () =>
-      process.env.NEXT_PUBLIC_SOLANA_URL ||
-      clusterApiUrl(WalletAdapterNetwork.Mainnet),
-    []
-  );
+export const endpoint =
+  process.env.NEXT_PUBLIC_SOLANA_URL ||
+  clusterApiUrl(WalletAdapterNetwork.Mainnet);
 
+const WalletAdapterProvider: FC<React.PropsWithChildren> = ({ children }) => {
   const { reownAdapter, jupiterAdapter } = useWrappedReownAdapter({
     appKitOptions: {
       metadata: {
@@ -42,7 +37,6 @@ export const WalletProvider: FC<React.PropsWithChildren> = ({ children }) => {
 
   const wallets = useMemo(
     () => [
-      // Solflare, Ledger, and Backpack use wallet standard
       new CoinbaseWalletAdapter(),
       reownAdapter,
       jupiterAdapter,
@@ -51,14 +45,22 @@ export const WalletProvider: FC<React.PropsWithChildren> = ({ children }) => {
   );
 
   return (
+    <SolanaWalletProvider
+      wallets={wallets}
+      autoConnect
+      onError={(err) => err.message.length && toast(err.message)}
+    >
+      <WalletModalProvider>{children}</WalletModalProvider>
+    </SolanaWalletProvider>
+  );
+};
+
+export const WalletProvider: FC<React.PropsWithChildren> = ({ children }) => {
+  return (
     <ConnectionProvider endpoint={endpoint}>
-      <SolanaWalletProvider
-        wallets={wallets}
-        autoConnect
-        onError={(err) => err.message.length && toast(err.message)}
-      >
-        <WalletModalProvider>{children}</WalletModalProvider>
-      </SolanaWalletProvider>
+      {children}
     </ConnectionProvider>
   );
 };
+
+export { WalletAdapterProvider };

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { FC } from "react";
-import { WalletProvider } from "./WalletProvider";
+import { WalletProvider, WalletAdapterProvider } from "./WalletProvider";
 import { AccountProvider } from "./AccountProvider";
 import { GovernanceProvider } from "./GovernanceProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -12,8 +12,6 @@ export const Providers: FC<React.PropsWithChildren> = ({ children }) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            // With SSR, we usually want to set some default staleTime
-            // above 0 to avoid refetching immediately on the client
             staleTime: 60 * 1000,
           },
         },
@@ -24,7 +22,9 @@ export const Providers: FC<React.PropsWithChildren> = ({ children }) => {
     <QueryClientProvider client={queryClient}>
       <WalletProvider>
         <AccountProvider>
-          <GovernanceProvider>{children}</GovernanceProvider>
+          <WalletAdapterProvider>
+            <GovernanceProvider>{children}</GovernanceProvider>
+          </WalletAdapterProvider>
         </AccountProvider>
       </WalletProvider>
     </QueryClientProvider>


### PR DESCRIPTION
## Summary

- Split `WalletProvider` into `ConnectionProvider` (available immediately) and `WalletAdapterProvider` (Reown/WalletConnect init), reordering the provider tree so connection-dependent hooks start fetching without waiting for the Reown SDK
- The Reown AppKit sends an `INITIALIZE` telemetry event to `pulse.walletconnect.org` regardless of `analytics: false` — this was blocking the entire provider tree including `AccountProvider` and `GovernanceProvider`
- No functional changes to wallet connection behavior; only the initialization order is affected

## Before/After

**Before:**
```
WalletProvider (ConnectionProvider + Reown init)
  └── AccountProvider (blocked until Reown completes)
      └── GovernanceProvider (blocked)
```

**After:**
```
WalletProvider (ConnectionProvider only — instant)
  └── AccountProvider (starts immediately)
      └── WalletAdapterProvider (Reown init, no longer blocking data)
          └── GovernanceProvider
```