### PR TITLE
Fix WalletConnect modal showing only social logins

### DIFF
--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -30,8 +30,9 @@ const WalletAdapterProvider: FC<React.PropsWithChildren> = ({ children }) => {
       projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "",
       features: {
         analytics: false,
+        socials: false,
+        email: false,
       },
-      enableWallets: false,
     },
   });
 


### PR DESCRIPTION
## Summary
- Fix regression from Reown upgrade where the Connect Wallet modal only showed social logins (Email, Google, X, Discord, GitHub) instead of WalletConnect QR codes
- `enableWallets: false` was disabling **all** wallet options including QR codes — replaced with `socials: false` and `email: false` to disable only the social login features
