### PR TITLE
HIP-149: re-point vote summary to corrected gist revision

### DIFF
--- a/helium-proposals.json
+++ b/helium-proposals.json
@@ -361,7 +361,7 @@
   },
   {
     "name": "HIP-149: Helium Utility and Emissions Realignment",
-    "uri": "https://gist.githubusercontent.com/hiptron/dbaf4c1df802bf3f32a0eb75cb1918a3/raw/411c4f0c1b5227798f4bcde29ce6c7e57a7206fc/HIP-149-Vote-Summary.md",
+    "uri": "https://gist.githubusercontent.com/hiptron/dbaf4c1df802bf3f32a0eb75cb1918a3/raw/7a6cdfd5fa48016bbeebd35ce30441fa5db5e1a5/HIP-149-Vote-Summary.md",
     "maxChoicesPerVoter": 1,
     "tags": ["Economic", "Technical"],
     "choices": [


### PR DESCRIPTION
Re-points the HIP-149 entry uri to the corrected vote-summary gist revision (`7a6cdfd5`): authors line now lists all four authors and the floor is described against the payer rate. Content is otherwise unchanged.