### PR TITLE
HIP-149 Advisory Council Election

### DIFF
--- a/helium-proposals.json
+++ b/helium-proposals.json
@@ -371,7 +371,7 @@
   },
   {
     "name": "HIP-149: Advisory Council Election",
-    "uri": "https://gist.githubusercontent.com/hiptron/60b0b7c20cbb37186054f88d86c29771/raw/21a55ba9f000133cb0dbddb1a2269345c0fa15da/hip149.md",
+    "uri": "https://gist.githubusercontent.com/hiptron/60b0b7c20cbb37186054f88d86c29771/raw/e4cdc86e89a079f22d12406bfd81bca1ee2024c0/hip149.md",
     "maxChoicesPerVoter": 5,
     "tags": ["advisory-council"],
     "choices": [

--- a/helium-proposals.json
+++ b/helium-proposals.json
@@ -371,22 +371,22 @@
   },
   {
     "name": "HIP-149: Advisory Council Election",
-    "uri": "https://gist.githubusercontent.com/hiptron/60b0b7c20cbb37186054f88d86c29771/raw/21a55ba9f000133cb0dbddb1a2269345c0fa15da/election-summary.md",
+    "uri": "https://gist.githubusercontent.com/hiptron/60b0b7c20cbb37186054f88d86c29771/raw/21a55ba9f000133cb0dbddb1a2269345c0fa15da/hip149.md",
     "maxChoicesPerVoter": 5,
     "tags": ["advisory-council"],
     "choices": [
-      { "uri": null, "name": "Adrian Clint (@waveformiot)" },
-      { "uri": null, "name": "Chris Ferebee (@ferebee)" },
-      { "uri": null, "name": "Eric Eife (@eme0967)" },
-      { "uri": null, "name": "Jacob Brady (@jhbr821)" },
-      { "uri": null, "name": "James Fayal (@jmf1)" },
-      { "uri": null, "name": "Jeremy Harris (@jpharris1981)" },
-      { "uri": null, "name": "Jeremy Mahrle (@jaym2518)" },
-      { "uri": null, "name": "Keith Rettig (@keith_rettig)" },
-      { "uri": null, "name": "Omar Henry (@maknbank)" },
-      { "uri": null, "name": "Pepe Ortiz (@perro69696969)" },
-      { "uri": null, "name": "Samuel Andrews, MD (@andrewsmd)" },
-      { "uri": null, "name": "Thomas Kuit (@tommyy3858)" }
+      { "uri": null, "name": "Adrian Clint" },
+      { "uri": null, "name": "Chris Ferebee" },
+      { "uri": null, "name": "Eric Eife" },
+      { "uri": null, "name": "Jacob Brady" },
+      { "uri": null, "name": "James Fayal" },
+      { "uri": null, "name": "Jeremy Harris" },
+      { "uri": null, "name": "Jeremy Mahrle" },
+      { "uri": null, "name": "Keith Rettig" },
+      { "uri": null, "name": "Omar Henry" },
+      { "uri": null, "name": "Pepe Ortiz" },
+      { "uri": null, "name": "Samuel Andrews, MD" },
+      { "uri": null, "name": "Thomas Kuit" }
     ]
   }
 ]


### PR DESCRIPTION
## Summary
HIP-149 Advisory Council Election: plain-name ballot labels + shorter gist URI (fit Squads V4 tx size)

Applied 13 exactly-once string replacement(s) to `helium-proposals.json`; entry count unchanged.

Reference: https://github.com/helium/HIP/issues/1201