### PR TITLE
Fix vote power overcounting for multi-choice votes in voter breakdown and CSV export

### DIFF
--- a/src/components/VoteBreakdown.tsx
+++ b/src/components/VoteBreakdown.tsx
@@ -39,51 +39,68 @@ export const VoteBreakdown: FC<{
     votesForProposalQuery({
       voteService,
       proposal: proposalKey,
-    })
+    }),
   );
   const { info: proposal, loading: loadingProp } = useProposal(proposalKey);
   const { info: proposalConfig, loading: loadingConf } = useProposalConfig(
-    proposal?.proposalConfig
+    proposal?.proposalConfig,
   );
   const { info: registrar, loading: loadingReg } = useRegistrar(
-    proposalConfig?.voteController
+    proposalConfig?.voteController,
   );
   const decimals = useMint(registrar?.votingMints[0].mint)?.info?.decimals;
-  const totalVotes = useMemo(
-    () =>
-      (proposal?.choices || []).reduce((acc, { weight }) => {
-        return acc.add(weight);
-      }, new BN(0)),
-    [proposal?.choices]
-  );
-
   const groupedSortedVotes = useMemo(() => {
     if (decimals) {
       const grouped = Object.values(
-        (votes || []).reduce((acc, vote) => {
-          const key = vote.voter;
-          if (!acc[key]) {
-            acc[key] = {
-              voter: vote.voter,
-              choices: [],
-              totalWeight: new BN(0),
-              proxyName: vote.proxyName,
-            };
-          }
+        (votes || []).reduce(
+          (acc, vote) => {
+            const key = vote.voter;
+            if (!acc[key]) {
+              acc[key] = {
+                voter: vote.voter,
+                choices: [],
+                totalWeight: new BN(0),
+                proxyName: vote.proxyName,
+              };
+            }
 
-          acc[key].choices.push(vote.choiceName);
-          acc[key].totalWeight = acc[key].totalWeight.add(new BN(vote.weight));
-          return acc;
-        }, {} as Record<string, { voter: string; choices: string[]; totalWeight: BN; proxyName?: string }>)
+            acc[key].choices.push(vote.choiceName);
+            // Each row carries the wallet's full vote power for that choice,
+            // so summing rows would multiply it by the number of choices
+            acc[key].totalWeight = BN.max(
+              acc[key].totalWeight,
+              new BN(vote.weight),
+            );
+            return acc;
+          },
+          {} as Record<
+            string,
+            {
+              voter: string;
+              choices: string[];
+              totalWeight: BN;
+              proxyName?: string;
+            }
+          >,
+        ),
       );
 
       const sortedMarkers = grouped.sort((a, b) =>
-        toNumber(b.totalWeight.sub(a.totalWeight), decimals)
+        toNumber(b.totalWeight.sub(a.totalWeight), decimals),
       );
 
       return sortedMarkers;
     }
   }, [votes, decimals]);
+
+  const totalVotes = useMemo(
+    () =>
+      (groupedSortedVotes || []).reduce(
+        (acc, { totalWeight }) => acc.add(totalWeight),
+        new BN(0),
+      ),
+    [groupedSortedVotes],
+  );
 
   const csvData = useMemo(() => {
     const rows: string[][] = [];
@@ -117,7 +134,7 @@ export const VoteBreakdown: FC<{
 
   const displayedVotes = useMemo(
     () => (groupedSortedVotes || []).slice(0, displayCount),
-    [groupedSortedVotes, displayCount]
+    [groupedSortedVotes, displayCount],
   );
 
   const handleCSVDownload = () => {
@@ -133,7 +150,7 @@ export const VoteBreakdown: FC<{
         `${proposal?.name
           .toLowerCase()
           .split(" ")
-          .join("_")}_vote_breakdown.csv`
+          .join("_")}_vote_breakdown.csv`,
       );
       link.style.visibility = "hidden";
       document.body.appendChild(link);
@@ -144,7 +161,7 @@ export const VoteBreakdown: FC<{
 
   const isLoading = useMemo(
     () => loadingVotes || loadingProp || loadingConf || loadingReg,
-    [loadingVotes, loadingProp, loadingConf, loadingReg]
+    [loadingVotes, loadingProp, loadingConf, loadingReg],
   );
 
   return (
@@ -185,7 +202,7 @@ export const VoteBreakdown: FC<{
                 key={vote.voter}
                 className={classNames(
                   "!hover:bg-initial",
-                  i % 2 === 0 ? "bg-slate-700" : "bg-slate-800"
+                  i % 2 === 0 ? "bg-slate-700" : "bg-slate-800",
                 )}
               >
                 <TableCell>


### PR DESCRIPTION
## Problem

In the Voter Breakdown table and its CSV export, the **Vote Power** column showed a wallet's vote power multiplied by the number of choices it voted for. A wallet with 100 veHNT voting for 5 candidates displayed 500 instead of 100.

## Cause

The vote service (`/v1/proposals/{proposal}/votes`) returns one row per **(voter, choice)**, and each row carries the wallet's **full** vote power — on-chain, a vote marker applies the position's full weight to every chosen choice. `VoteBreakdown.tsx` grouped rows by voter and **summed** their weights, overcounting by the choice count.

Verified against live data for the HIP-149 Advisory Council Election (`Eejcqoyp…LRx4`): all 111 multi-choice voters had their vote power inflated, e.g.

| Voter | Choices | Actual vote power | Displayed |
|---|---|---|---|
| `1twV1sVZ…` | 5 | 53,251.96 | 266,259.83 (5×) |
| `2qQW7R6y…` | 3 | 2,179.06 | 6,537.18 (3×) |

## Fix

- **Vote power**: combine a wallet's rows with `BN.max` instead of `add`. Max (rather than "take any row") matters because a wallet's per-choice weights can genuinely differ — e.g. one voter in this election has 6 rows with different weights from re-voting after locking more veHNT.
- **Percentage**: the denominator previously summed the proposal's per-choice totals, which double-counts multi-choice voters the same way. It's now the sum of unique per-wallet weights, so wallet percentages sum to 100%.

Single-choice proposals are numerically unchanged by both edits (max of one row = the row; grouped totals = choice totals).

## Verification

- Script replaying the fixed grouping against the live vote service: green for all 111 multi-choice voters (red with the old sum logic).
- `tsc --noEmit`: no errors in the changed file (5 pre-existing unrelated module-resolution errors remain).

Note: the diff includes formatting churn (trailing commas) from a local prettier hook.